### PR TITLE
workbox to cache images

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/common": "6.0.3",
-    "@angular/core": "6.0.3",
-    "@angular/compiler": "6.0.3",
     "@angular/animations": "6.0.3",
     "@angular/cdk": "^6.2.0",
+    "@angular/common": "6.0.3",
+    "@angular/compiler": "6.0.3",
     "@angular/compiler-cli": "^6.0.3",
+    "@angular/core": "6.0.3",
     "@angular/forms": "6.0.3",
     "@angular/http": "6.0.3",
     "@angular/material": "^6.2.0",
@@ -49,18 +49,14 @@
     "rxjs-tslint": "^0.1.4",
     "uglify-js": "^3.3.24",
     "web-animations-js": "^2.3.1",
-    "workbox-build": "2.1.1",
+    "workbox-build": "2.1.2",
     "zone.js": "^0.8.14"
   },
   "devDependencies": {
-    "@angular/compiler-cli": "^6.0.3",
-    "@angular-devkit/build-ng-packagr": "~0.6.6",
     "@angular-devkit/build-angular": "~0.6.6",
-    "ng-packagr": "^3.0.0-rc.2",
-    "tsickle": ">=0.25.5",
-    "tslib": "^1.7.1",
-    "typescript": "2.7.1",
+    "@angular-devkit/build-ng-packagr": "~0.6.6",
     "@angular/cli": "^6.0.7",
+    "@angular/compiler-cli": "^6.0.3",
     "@angular/language-service": "^6.0.3",
     "@types/fs-extra": "^5.0.2",
     "@types/jasmine": "~2.5.53",
@@ -76,8 +72,12 @@
     "karma-coverage-istanbul-reporter": "^1.2.1",
     "karma-jasmine": "~1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",
+    "ng-packagr": "^3.0.0-rc.2",
     "protractor": "~5.1.2",
     "ts-node": "~3.2.0",
-    "tslint": "~5.3.2"
+    "tsickle": ">=0.25.5",
+    "tslib": "^1.7.1",
+    "tslint": "~5.3.2",
+    "typescript": "2.7.2"
   }
 }

--- a/src/sw-template.js
+++ b/src/sw-template.js
@@ -21,21 +21,19 @@ const webFontHandler = w.strategies.cacheFirst({
   },
   cacheableResponse: { statuses: [0, 200] }
 });
-w.router.registerRoute('https://fonts.googleapis.com/(.*)', webFontHandler);
-w.router.registerRoute('https://fonts.gstatic.com/(.*)', webFontHandler);
-w.router.registerRoute('https://use.fontawesome.com/(.*)', webFontHandler);
+w.router.registerRoute(/https:\/\/fonts.googleapis.com\/.*/, webFontHandler);
+w.router.registerRoute(/https:\/\/fonts.gstatic.com\/.*/, webFontHandler);
+w.router.registerRoute(/https:\/\/use.fontawesome.com\/.*/, webFontHandler);
 
-// get-urls-cache
-const API = 'https://us-central1-joanne-lee.cloudfunctions.net/getUrls/(.*)';
-const apiHandler = w.strategies.networkFirst({
-  cacheName: 'get-urls-cache'
-});
-w.router.registerRoute(API, apiHandler);
-
-// work-images-cache
-w.router.registerRoute('https://storage.googleapis.com/joanne-lee.appspot.com/(.*)',
+// storage-cache
+const STORAGE1 = /https:\/\/firebasestorage.googleapis.com\/v0\/b\/ng-notes-abb75.appspot.com\/o\/.*/;
+const STORAGE2 = /https:\/\/storage.googleapis.com\/ng-notes-abb75.appspot.com\/.*/;
+const matchCb = ({url, event}) => {
+  return STORAGE1.test(url) || STORAGE2.test(url) ? {url} : null;
+};
+w.router.registerRoute(matchCb,
   w.strategies.cacheFirst({
-    cacheName: 'work-images-cache',
+    cacheName: 'storage-cache',
     cacheExpiration: {
       maxEntries: 60
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7212,11 +7212,7 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@2.7.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.1.tgz#bb3682c2c791ac90e7c6210b26478a8da085c359"
-
-"typescript@>=2.6.2 <2.8", typescript@~2.7.2:
+typescript@2.7.2, "typescript@>=2.6.2 <2.8", typescript@~2.7.2:
   version "2.7.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
 
@@ -7697,18 +7693,18 @@ wordwrap@~0.0.2:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
 
-workbox-build@2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/workbox-build/-/workbox-build-2.1.1.tgz#9d92bca4a760e44799346fac1efb41ddb2f7f4b1"
+workbox-build@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/workbox-build/-/workbox-build-2.1.2.tgz#5425094a83ac77c991b6060dd1df3d37984ef87e"
   dependencies:
     chalk "^1.1.3"
     fs-extra "^3.0.1"
     glob "^7.1.1"
     lodash.template "^4.4.0"
     mkdirp "^0.5.1"
-    workbox-sw "^2.1.1"
+    workbox-sw "^2.1.2"
 
-workbox-sw@^2.1.1:
+workbox-sw@^2.1.2:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/workbox-sw/-/workbox-sw-2.1.3.tgz#4045560dc26ada7a41fe37999a93c71c43e41d6a"
 


### PR DESCRIPTION
- upgrade to `workbox-build@2.1.2`
- `registerRoute` using `matchCb` and `RegExp` to cache storage contents