### PR TITLE
ng-lazy-load 1.0.1

### DIFF
--- a/projects/ng-lazy-load/README.md
+++ b/projects/ng-lazy-load/README.md
@@ -3,44 +3,92 @@
 [![npm](https://img.shields.io/npm/v/ng-lazy-load.svg)](https://www.npmjs.com/package/ng-lazy-load)
 [![npm License](https://img.shields.io/npm/l/ng-lazy-load.svg?style=flat-square)](https://opensource.org/licenses/mit-license.php)
 
-`ng-lazy-load` library is an extension of [@trademe/ng-defer-load](https://github.com/TradeMe/ng-defer-load) to allow more control on its behaviour. You can use `lazyLoad` directive with optional `manualRegister` attribute, `[url]` input, `[index]` input and `LazyLoadService` as required.
+`ng-lazy-load` library provides `lazyLoad` directive and `LazyLoadService` to lazy load your resource file when it is near to be shown on screen. This library is an extension of [@trademe/ng-defer-load](https://github.com/TradeMe/ng-defer-load) to allow more control on its behaviour and make it useful in `ngFor` loop. The library will output debug logs to console in the development mode to show what's happening inside the library:
+```
+...
+lazyLoad never
+lazyLoad register
+loading [0] (Intersecting)
+loading [1] (NearIntersecting 0)
+loading [2] (NearIntersecting 0)
+loading [5] (Intersecting)
+...
+```
 
+## Usage
+
+Simplest usage would be:
 ```html
-<my-element
+<div (lazyLoad)="toLoad=true">
+  <img [src]="toLoad ? url : ''">
+</div>
+```
+
+A typical usage for `ngFor` loop would be:
+```html
+<my-element #myElement
     *ngFor="let item of items$ | async; let i = index"
-    lazyLoad
-    [url]="item.url"
-    [index]="i" 
-    manualRegister>
+    (lazyLoad)="myElement.doLoad($event)" [url]="item.url" [index]="i" >
 </my-element>
 ```
 ```javascript
-// in MyElementComponent
-constructor(private lazyLoadService: LazyLoadService) {
-  this.lazyLoadService.announcedIntersection.subscribe(params => {
-    const { index, state } = params;
-    if ((this.index - index) <= 2) {
-      this.toLoad = true; // to load 2 resources ahead beyond the intersecting index
-    }
-  });
+// in my-element component
+import { IntersectionState } from 'ng-lazy-load';
+
+doLoad(state: IntersectionState) {
+  this.toLoad = true;
 }
+```
+By having additional `[url]` and `[index]` inputs, the directive can choose to register the api only for elements that has a resource to load and provide some flexibility in its behaviour to cope with various needs.
+
+### LazyLoadService.loadAheadCount
+
+Default value of `LazyLoadService.loadAheadCount` property is 2 which means that if [n]th element is intersecting, [n+1]th and [n+2]th elements will also be loaded as well.
+You can override this by setting to other value:
+```javascript
+// in parent component
+import { LazyLoadService } from 'ng-lazy-load';
+
+constructor(private lazyLoadService: LazyLoadService) { }
+
+ngOnInit() {
+  this.lazyLoadService.loadAheadCount = 5; // load 5 elements ahead beyond the intersecting one
+```
+
+### LazyLoadService.registerAfter()
+
+By default, `lazyLoad` directive will register the `IntersectionObserver` api on its host element's init. But you may want to delay its registration:
+```javascript
 // in parent component
 ngOnInit() {
-  setTimeout(_ => this.lazyLoadService.announceOrder('register'), 1500);
+  this.lazyLoadService.registerAfter(1500); // let directives register after 1500 msec 
+```
+
+### LazyLoadService.registerLater() and LazyLoadService.registerAll()
+
+Or let directives register later when asked by the parent component:
+```javascript
+// in parent component
+ngOnInit() {
+  this.lazyLoadService.registerLater(); // let directives not register on init
 }
+// somewhere in parent component
+this.lazyLoadService.registerAll(); // let directives register now
 ```
 
 A [Stackblitz demo](https://stackblitz.com/edit/angular-deferload-not-working-with-animation) is available to show the usage.
+
+## Installation
 
 ```
 // to install
 npm install ng-lazy-load
 
 // in app.module.ts
-import { NgLazyLoadModule } from 'ng-lazy-load';
+import { LazyLoadModule } from 'ng-lazy-load';
 @NgModule({
   imports: [
-    NgLazyLoadModule,
+    LazyLoadModule,
 
 // in template
 <div (lazyLoad)="toLoad=true">

--- a/projects/ng-lazy-load/package.json
+++ b/projects/ng-lazy-load/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-lazy-load",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A library to enable lazy loading offscreen resource files",
   "repository": {
     "type": "git",

--- a/projects/ng-lazy-load/src/lib/ng-lazy-load.module.ts
+++ b/projects/ng-lazy-load/src/lib/ng-lazy-load.module.ts
@@ -7,4 +7,4 @@ import { LazyLoadDirective } from './ng-lazy-load.directive';
   declarations: [LazyLoadDirective],
   exports: [LazyLoadDirective]
 })
-export class NgLazyLoadModule { }
+export class LazyLoadModule { }

--- a/projects/ng-lazy-load/src/lib/ng-lazy-load.service.ts
+++ b/projects/ng-lazy-load/src/lib/ng-lazy-load.service.ts
@@ -5,27 +5,55 @@ export enum IntersectionState {
   Disconnected,
   None,
   Intersecting,
+  NearIntersecting,
   Visible,
   Prerender
 }
+
+const LOAD_AHEAD_COUNT = 2;
 
 @Injectable({
   providedIn: 'root'
 })
 export class LazyLoadService {
   isDevMode = isDevMode();
+
+  private _loadAheadCount = LOAD_AHEAD_COUNT;
+  get loadAheadCount() { return this._loadAheadCount; }
+  set loadAheadCount(value: number) {
+    this._loadAheadCount = value; 
+    if (this.isDevMode) console.log(`loadAheadCount set to (${value})`);
+  }
+
+  delayMsec = 0;
+  registerAfter(msec: number) {
+    if (msec > 0) {
+      this.delayMsec = msec;
+      setTimeout(_ => this.announceOrder('register'), msec);
+    }
+  }
+  registerLater() {
+    this.delayMsec = 1; // let the directive not register on init
+  }
+  registerAll() {
+    this.announceOrder('register');
+  }
   
-  // announce order to [lazyLoad] directives of ngFor children
+  // announce order to [lazyLoad] directives
   private order$ = new Subject<string>();
   announcedOrder = this.order$.asObservable();
   announceOrder(name: string) {
     this.order$.next(name);
   }
 
-  // announce intersecting event to ngFor children components
+  // announce intersecting index to [lazyLoad] directives
   private intersection$ = new Subject<any>(); 
   announcedIntersection = this.intersection$.asObservable();
   announceIntersection(params: object) { // { index: number, state: IntersectionState }
     this.intersection$.next(params);
+  }
+
+  constructor() {
+    if (this.isDevMode) console.log(`'LazyLoadService' loadAheadCount`, this._loadAheadCount);
   }
 }

--- a/src/app/our-notes/group/group.component.html
+++ b/src/app/our-notes/group/group.component.html
@@ -7,7 +7,7 @@
     [note]="note" (toAddOrEdit)="addOrEdit($event)" (toRemove)="remove($event)" 
     *ngFor="let note of noteService.items$ | async; let i = index; trackBy: trackByFn"
     [ngClass]="{ 'modified' : note.$type === 'modified' && noteService.listState === 'modified' }"
-    lazyLoad [url]="note.imageURL" [index]="i" manualRegister
+    (lazyLoad)="myNote.doLoad($event,i)" [url]="note.imageURL" [index]="i" #myNote
     [attr.tabindex]="i">
   </my-note>
 </div>

--- a/src/app/our-notes/group/group.component.ts
+++ b/src/app/our-notes/group/group.component.ts
@@ -32,13 +32,13 @@ export class GroupComponent implements OnInit, OnDestroy {
     private lazyLoadService: LazyLoadService,
     private modalService: ModalService) {
 
-    console.log('GroupComponent()');
-
+      
     this.subscription = route.params.subscribe(params => {
       if (!this.init) return;
 
       console.log('GroupComponent params', params);
     })
+    console.log('GroupComponent()');
   }
 
   ngOnInit() {
@@ -86,7 +86,7 @@ export class GroupComponent implements OnInit, OnDestroy {
 
       this.init = true;
 
-      setTimeout(_ => this.lazyLoadService.announceOrder('register'), 1500);
+      this.lazyLoadService.registerAfter(1500);
     }
   }
 

--- a/src/app/our-notes/group/note/note.component.ts
+++ b/src/app/our-notes/group/note/note.component.ts
@@ -1,22 +1,18 @@
-import { Component, Input, Output, ElementRef, EventEmitter, OnDestroy } from '@angular/core';
+import { Component, Input, Output, ElementRef, EventEmitter } from '@angular/core';
 import { NoteService } from '../../note.service';
-import { LazyLoadService, IntersectionState } from 'ng-lazy-load';
-import { Subscription } from 'rxjs';
-
-const LOAD_AHEAD_COUNT = 0;
+import { IntersectionState } from 'ng-lazy-load';
 
 @Component({
   selector: 'my-note',
   templateUrl: './note.component.html',
   styleUrls: ['./note.component.css']
 })
-export class NoteComponent implements OnDestroy {
+export class NoteComponent {
   @Input() note: any;
   @Input() index: number;
   @Output() toAddOrEdit: EventEmitter<any> = new EventEmitter();
   @Output() toRemove: EventEmitter<any> = new EventEmitter();
   toLoad = false; // local state for lazy-loading offscreen images
-  private _subcription: Subscription;
 
   get imageURL() { 
     return this.toLoad && this.note.imageURL && this.note.imageURL.indexOf('images') > -1 ? this.note.imageURL : ''; 
@@ -26,23 +22,7 @@ export class NoteComponent implements OnDestroy {
   }
 
   constructor(private el: ElementRef,
-    private noteService: NoteService,
-    private lazyLoadService: LazyLoadService) {
-
-    this._subcription = this.lazyLoadService.announcedIntersection.subscribe(params => {
-      const { index, state } = params;
-      if (!this.toLoad && (this.index - index) <= LOAD_AHEAD_COUNT) {
-        this.toLoad = true;
-        console.log(`(${index},${IntersectionState[state]}) loading [${this.index}]`);
-      }
-    });
-  }
-
-  ngOnDestroy() {
-    if (this._subcription) {
-      this._subcription.unsubscribe();
-    }
-  }
+    private noteService: NoteService) { }
 
   edit({ event, done }) {
     console.log(`edit`);
@@ -78,8 +58,7 @@ export class NoteComponent implements OnDestroy {
   }
 
   doLoad(state: IntersectionState, index) {
-    this.toLoad = state > IntersectionState.None;
-    console.log(`doLoad [${index}] ${IntersectionState[state]}`);
+    this.toLoad = true;
   }
 
 

--- a/src/app/our-notes/our-notes.module.ts
+++ b/src/app/our-notes/our-notes.module.ts
@@ -21,7 +21,7 @@ import { AfterIfDirective } from '../after-if.directive';
 import { NgIdleClickModule } from 'ng-idle-click';
 import { NgInputFileModule } from 'ng-input-file';
 import { NgScrolltopModule } from 'ng-scrolltop';
-import { NgLazyLoadModule } from 'ng-lazy-load';
+import { LazyLoadModule } from 'ng-lazy-load';
 import { TouchStartModule } from '../touchstart.module';
 
 import { OurNotesRoutingModule } from './our-notes-routing.module';
@@ -39,7 +39,7 @@ import { OurNotesRoutingModule } from './our-notes-routing.module';
     NgIdleClickModule,
     NgInputFileModule,
     NgScrolltopModule,
-    NgLazyLoadModule,
+    LazyLoadModule,
   ],
   declarations: [
     OurNotesComponent,


### PR DESCRIPTION
- `lazyLoad` to listen to intersecting index
- `manualRegister` attribute gone
- simpler new api: `registerAfter`, `registerLater`, `registerAll`, `loadAheadCount`
- module renamed `LazyLoadModule`